### PR TITLE
Updated build.gradle with compile statements for Parse

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,8 +25,8 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
     compile 'com.android.support:appcompat-v7:23.1.1'
-    compile files('libs/Parse-1.11.0.jar')
-    compile files('libs/bolts-tasks-1.3.0.jar')
+    compile 'com.parse.bolts:bolts-android:1.3.0'
+    compile 'com.parse:parse-android:1.11.0'
     compile 'com.android.support:design:23.1.1'
     compile 'com.android.support:cardview-v7:23.1.1'
 }


### PR DESCRIPTION
Rather than continuing to build from jars for the Parse libraries, I suggest that we switch to letting gradle manage the dependencies and source the library.
